### PR TITLE
Fixing test fixtures and BUGFIX with YAML loading

### DIFF
--- a/lib/facebooker.rb
+++ b/lib/facebooker.rb
@@ -54,8 +54,8 @@ module Facebooker
     # By default the hash passed in is loaded from facebooker.yml, but it can also be passed in
     # manually every request to run multiple Facebook apps off one Rails app. 
     def apply_configuration(config)
-      ENV['FACEBOOK_API_KEY']             = config['api_key']
-      ENV['FACEBOOK_SECRET_KEY']          = config['secret_key']
+      ENV['FACEBOOK_API_KEY']             = config['api_key'].to_s
+      ENV['FACEBOOK_SECRET_KEY']          = config['secret_key'].to_s
       ENV['FACEBOOKER_RELATIVE_URL_ROOT'] = config['canvas_page_name']
       ENV['FACEBOOKER_API']               = config['api']
       if config.has_key?('set_asset_host_to_callback_url')

--- a/lib/facebooker/mock/service.rb
+++ b/lib/facebooker/mock/service.rb
@@ -14,23 +14,26 @@ module Facebooker
     end
 
     def read_fixture(method, filename, original = nil)
-      path = fixture_path(method, filename)
-      File.read path
-    rescue Errno::ENAMETOOLONG
-      read_fixture(method, hash_fixture_name(filename), filename)
-    rescue Errno::ENOENT => e
-      if File.exists?(fixture_path(method, 'default'))
-        File.read fixture_path(method, 'default')
-      else
-        e.message << "\n(Non-hashed path is #{original})" if original
-        e.message << "\nFacebook API Reference: http://wiki.developers.facebook.com/index.php/#{method.sub(/^facebook\./, '')}#Example_Return_XML"
-        raise e
+      begin
+        path = fixture_path(method, filename)
+        File.read path
+      rescue Errno::ENAMETOOLONG
+        read_fixture(method, hash_fixture_name(filename), filename)
+      rescue Errno::ENOENT => e
+        if File.exists?(fixture_path(method, 'default'))
+          File.read fixture_path(method, 'default')
+        else
+          e.message << "\nPut the XML content in this file, or #{fixture_path(method,'default')}"
+          e.message << "\nFacebook API Reference: http://wiki.developers.facebook.com/index.php/#{method.sub(/^facebook\./, '')}#Example_Return_XML"
+          e.message << "\n(Non-hashed path is #{original})" if original
+          raise e
+        end
       end
     end
 
     def post(params)
       method = params.delete(:method)
-      params.delete_if {|k,_| [:v, :api_key, :call_id, :sig].include?(k) }
+      params.delete_if {|k,_| [:v, :api_key, :session_key, :call_id, :sig].include?(k) }
       Parser.parse(method, read_fixture(method, fixture_name(params)))
     end
 


### PR DESCRIPTION
Hi folks,

Unfortunately two commits in one here (I'd rather just send 399f6071, but a85c2fc3 may have some benefit)

a85c2fc3: Fixes the fixtures so as that the fixture path is hashed when it's too long for the filesystem (code was there, but didn't seem to trigger). Updated error message to give the user more of a clue about what they need to do.

399f6071: Ran into an issue in production where the api_key in our YAML file looked exactly like an integer, so it was parsed as a Fixnum, causing an exception. Trivial patch to make sure that it's coerced to a string when used.

Questions or comments, just let me know.

Cheers in advance,
Jason
